### PR TITLE
remove the projectID from PacketMachine crd

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -46,8 +46,6 @@ spec:
               type: array
             machineType:
               type: string
-            projectID:
-              type: string
             providerID:
               description: ProviderID is the unique identifier as specified by the
                 cloud provider.
@@ -66,7 +64,6 @@ spec:
           - OS
           - billingCycle
           - machineType
-          - projectID
           type: object
         status:
           description: PacketMachineStatus defines the observed state of PacketMachine


### PR DESCRIPTION
It does not look like the PacketMachine needs a ProjectID. It is a value
that we get from the PacketCluster.

It is not even generated from the `make examples` file and when applied
via kubectl it fails because PachetMachine.ProjectID is a required field
in openapi.