### PR TITLE
fix ci installing kubebuilder

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,8 +14,11 @@ steps:
 - name: test
   pull: always
   image: golang:1.14.2-alpine3.11
+  environment:
+    CGO_ENABLED: 0
   commands:
   - apk --update add make git bash jq curl
+  - make kubebuilder
   - make test
 
 - name: image

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 .PHONY: vendor test manager clusterctl run install deploy manifests generate fmt vet run kubebuilder ci cd
 
-#KUBEBUILDER_VERSION ?= 2.3.0
-# because of a known bug in 2.3.0, notably the one fixed in https://github.com/kubernetes-sigs/kubebuilder/pull/1417
-# we will use master until 2.3.1 (or 2.4.0) comes out
-KUBEBUILDER_VERSION ?= master
+KUBEBUILDER_VERSION ?= 2.3.1
 KUBEBUILDER ?= /usr/local/kubebuilder/bin/kubebuilder
 
 GIT_VERSION?=$(shell git log -1 --format="%h")


### PR DESCRIPTION
At the end of the story it took me an hour to understand the issue and 1
minutes to fix it. I suppose.

The kubebuilder installation process is already part of the Makefile,
but it was not used in CI.

now it should work.