### PR TITLE
trigger finalizer even if the machine is already deleted from packet

### DIFF
--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,8 +38,9 @@ import (
 // PacketClusterReconciler reconciles a PacketCluster object
 type PacketClusterReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log      logr.Logger
+	Recorder record.EventRecorder
+	Scheme   *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=packetclusters,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
If we attempt to remove a machine that is not running on Packet (for any
reason), we are in a loop where the reconciler returns 404 from Packet
API and the source never gets deleted.

This code should check for a 404, and it should pass forward the
finalizer trigger a garbage collection.

I presume we do not need to check for the number of `instances` anymore,
because if they are `0` we never get over the `not found error`.