### PR TITLE
bootstrap data secret must be set

### DIFF
--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -174,9 +174,9 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 		return ctrl.Result{}, nil
 	}
 
-	// Make sure bootstrap data is available and populated.
-	if machineScope.Machine.Spec.Bootstrap.Data == nil {
-		machineScope.Info("Bootstrap data is not yet available")
+	// Make sure bootstrap data secret is available and populated.
+	if machineScope.Machine.Spec.Bootstrap.DataSecretName == nil {
+		machineScope.Info("Bootstrap data secret is not yet available")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
From v1alpha2 to v1alpha3 the Bootstrap.Data field got deprecated in
favour of Bootstrap.DataSecretName as you can see:

https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#data-generated-from-a-bootstrap-provider-is-now-stored-in-a-secret