### PR TITLE
clusterctl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is the official [cluster-api](https://github.com/kubernetes-sigs/cluster-ap
 ## Using
 
 The following section describes how to use the cluster-api provider for packet (CAPP) as a regular user.
+You do _not_ need to clone this repository, or install any special tools, other than the standard
+`kubectl` and `clusterctl`; see below.
 
 To build CAPP, release it, and to deploy individual components, see [docs/BUILD.md](./docs/BUILD.md).
 
@@ -36,17 +38,27 @@ To deploy a cluster via the cluster-api:
 1. Create a project in Packet, using one of: the [API](https://www.packet.com/developers/api/), one of the many [SDKs](https://www.packet.com/developers/libraries/), the [CLI](https://github.com/packethost/packet-cli) or the [Web UI](https://app.packet.net).
 1. Create an API key for the project save it
 1. Deploy your bootstrap cluster and set the environment variable `KUBECONFIG` (optional)
-1. Initialize the cluster: `clusterctl --config=out/release/infrastructure-packet/<version>/ init`
+1. Initialize the cluster (see below)
 1. Generate your cluster yaml (see below)
 1. Apply your cluster yaml (see below)
 
-### Generate Cluster yaml
+#### Initialize the Cluster
+
+To initialize the cluster:
+
+```
+clusterctl --config=https://github.com/packethost/cluster-api-provider-packet/releases/latest/clusterctl.yaml init --infrastructure=packet
+```
+
+We are in the process of working with the core cluster-api team, so that you will not need the
+`--config=` option, hopefully soon.
+
+#### Generate Cluster yaml
 
 To generate your cluster yaml:
 
 1. Set the required environment variables:
    * `PACKET_PROJECT_ID` - Packet project ID
-   * `PACKET_API_KEY` - Packet API key from the initialization steps
    * `PACKET_FACILITY` - The Packet facility where you wantto deploy the cluster. If not set, it will default to `ewr1`.
 1. (Optional) Set the optional environment variables:
    * `CLUSTER_NAME` - The created cluster will have this name. If not set, it will generate one for you, see defaults below.
@@ -56,13 +68,29 @@ To generate your cluster yaml:
    * `SERVICE_CIDR` - The CIDR to use for your services; if not set, see defaults below
    * `MASTER_NODE_TYPE` - The Packet node type to use for control plane nodes; if not set, see defaults below
    * `WORKER_NODE_TYPE` - The Packet node type to use for worker nodes; if not set, see defaults below
-1. Create the config file you need via `make generate`. This will generate the file [out/cluster.yaml](./out/cluster.yaml)
-1. If desired, edit [out/cluster.yaml](./out/cluster.yaml) to change settings, including network CIDRs and machine types and quantity
-1. Apply the files via `kubectl apply -f ./out/cluster.yaml`
+1. Run the cluster generation command:
 
-TODO: The files should be generated and applied via `clusterctl`
+```
+clusterctl --config=https://github.com/packethost/cluster-api-provider-packet/releases/latest/clusterctl.yaml config cluster <cluster-name> > out/cluster.yaml
+```
 
-#### Defaults
+Note that the above command will make _all_ of the environment variables required. This is a limitation of
+`clusterctl` that is in the process of being fixed. If you want to use the defaults, instead of running
+the above `clusterctl` command, run:
+
+```
+make cluster
+```
+
+This will:
+
+1. Generate a random cluster name
+1. Set the defaults
+1. Accept any of your overrides for those defaults
+1. Generate the output
+1. Tell you where it is an the `kubectl apply` command to run
+
+##### Defaults
 
 If you do not change the generated `yaml` files, it will use defaults. You can look in the [templates/cluster-template.yaml](./templates/cluster.yaml) file for details.
 
@@ -74,6 +102,18 @@ If you do not change the generated `yaml` files, it will use defaults. You can l
 * worker node type: `t1.small`
 * worker and master OS type: `ubuntu_18_04`
 
+#### Apply Your Cluster
+
+```
+kubectl apply -f cluster.yaml
+```
+
+Now wait for it to come up. You can check the status with any of the following commands:
+
+```
+kubectl get cluster
+kubectl get machine
+```
 
 ## How It Works
 

--- a/config/manager/credentials.yaml
+++ b/config/manager/credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manager-api-credentials
+type: Opaque
+data:
+  PACKET_API_KEY: ${PACKET_API_KEY}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - manager.yaml
+- credentials.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,4 +29,7 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        envFrom:
+        - secretRef:
+            name: manager-api-credentials
       terminationGracePeriodSeconds: 10

--- a/scripts/generate-cluster.sh
+++ b/scripts/generate-cluster.sh
@@ -2,14 +2,33 @@
 
 set -e
 
-TEMPLATE_IN=./templates/cluster-template.yaml
+# default configure URL
+CONFIG_URL=${CONFIG_URL:-https://github.com/packethost/cluster-api-provider-packet/releases/latest/clusterctl.yaml}
+
 TEMPLATE_OUT=./out/cluster.yaml
 
+DEFAULT_KUBERNETES_VERSION=1.18.2
 DEFAULT_POD_CIDR="172.25.0.0/16"
 DEFAULT_SERVICE_CIDR="172.26.0.0/16"
 DEFAULT_MASTER_NODE_TYPE="t1.small"
 DEFAULT_WORKER_NODE_TYPE="t1.small"
 DEFAULT_NODE_OS="ubuntu_18_04"
+
+# check required environment variables
+errstring=""
+
+if [ -z "$PACKET_PROJECT_ID" ]; then
+	errstring="${errstring} PACKET_PROJECT_ID"
+fi
+if [ -z "$PACKET_FACILITY" ]; then
+	errstring="${errstring} PACKET_FACILITY"
+fi
+
+if [ -n "$errstring" ]; then
+	echo "must set environment variables: ${errstring}" >&2
+	exit 1
+fi
+
 
 # Generate a somewhat unique cluster name. This only needs to be unique per project.
 RANDOM_STRING=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c5 | tr '[:upper:]' '[:lower:]')
@@ -22,28 +41,17 @@ POD_CIDR=${POD_CIDR:-${DEFAULT_POD_CIDR}}
 SERVICE_CIDR=${SERVICE_CIDR:-${DEFAULT_SERVICE_CIDR}}
 WORKER_NODE_TYPE=${WORKER_NODE_TYPE:-${DEFAULT_WORKER_NODE_TYPE}}
 MASTER_NODE_TYPE=${MASTER_NODE_TYPE:-${DEFAULT_MASTER_NODE_TYPE}}
-NODE_OS=${NODE_OS:=${DEFAULT_NODE_OS}}
+NODE_OS=${NODE_OS:-${DEFAULT_NODE_OS}}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:${DEFAULT_KUBERNETES_VERSION}}
+SSH_KEY=${SSH_KEY:-""}
 
-if [ -z "$PACKET_PROJECT_ID" ]; then
-	echo "must set environment variable PACKET_PROJECT_ID" >&2
-	exit 1
-fi
 PROJECT_ID=${PACKET_PROJECT_ID}
-if [ -z "$PACKET_FACILITY" ]; then
-	echo "must set environment variable PACKET_FACILITY" >&2
-	exit 1
-fi
 FACILITY=${PACKET_FACILITY}
 
-# uses the template to generate an example
-if [ ! -e "$TEMPLATE_IN" ]; then
-	echo "failed to find template file $TEMPLATE_IN" >&2
-	exit 1
-fi
-
 # and now export them all so envsubst can use them
-export PROJECT_ID FACILITY NODE_OS WORKER_NODE_TYPE MASTER_NODE_TYPE POD_CIDR SERVICE_CIDR CLUSTER_NAME SSH_KEY
-cat $TEMPLATE_IN | envsubst > $TEMPLATE_OUT
+export PROJECT_ID FACILITY NODE_OS WORKER_NODE_TYPE MASTER_NODE_TYPE POD_CIDR SERVICE_CIDR SSH_KEY KUBERNETES_VERSION
+clusterctl --config=${CONFIG_URL} config cluster ${CLUSTER_NAME} > $TEMPLATE_OUT
 
-echo "Done! See output file at ${TEMPLATE_OUT}"
+echo "Done! See output file at ${TEMPLATE_OUT}. Run:"
+echo "   kubectl apply -f ${TEMPLATE_OUT}"
 exit 0

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -18,7 +18,7 @@ spec:
     - systemctl daemon-reload
     - systemctl enable docker
     - systemctl start docker
-  postKubeadmCommands: 
+  postKubeadmCommands:
     - "kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://docs.projectcalico.org/v3.11/manifests/calico.yaml"
     - "kubectl --kubeconfig /etc/kubernetes/admin.conf create secret generic -n kube-system packet-cloud-config --from-literal=cloud-sa.json='{\"apiKey\": \"${PACKET_API_KEY}\",\"projectID\": \"${PROJECT_ID}\"}'"
     - "kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://raw.githubusercontent.com/packethost/packet-ccm/master/deploy/releases/v1.0.0/deployment.yaml"
@@ -92,7 +92,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     pool: worker-a
 spec:
-  replicas: 3
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -154,4 +154,4 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: external 
+            cloud-provider: external


### PR DESCRIPTION
This provides support for clusterctl in two ways.

First, it properly structures it so you can run `clusterctl --config=...` to initialize the Packet provider. It did work before, but there were elements missing. This completes it so that it works. As part of it, it needed to change some of how the templates are generated to `./out/`.

Second, it adds support for the cluster template in the right directories in `./out/`. This means that `generate-example.sh` is no longer relevant, although it uses the same source template. This now is pushed into the correct `./out/` directories, where `clusterctl` can consume them.

Since `clusterctl config cluster` does _not_ (yet) support defaults - every env var _must_ be set for it to work - this repurposes `generate-example.sh` to `generate-cluster.sh`, which wraps `clusterctl` but sets defaults for env vars that should support them (as it did before when it was `generate-example.sh`). Also moved that to `./scripts/` to keep it clean and consistent.

Other things had to be improved to make it work, for example adding the correct `Secret` to run the manager as part of `make release` (it isn't needed in `managerless`, since we run it locally).

All of the docs relating to it have been updated as well, as have Makefile targets.

There are a few things that still do not work or require fixing once this PR is in, but should be handled as separate steps.

* Our cluster template requires `PACKET_API_KEY` as part of its template, so that the CCM deployment will work correctly. Cluster templates are not supposed to have secrets. Even though we had it in v1alpha1, and this is a carryover, this requires us to clean it up. We need to find a way to get the secret across from the initializer in the management cluster. I have some ideas; we can follow through later.
* The actual `clusterctl --config=` command - both in the README and in `make cluster` - does not work because it references the URL https://github.com/packethost/cluster-api-provider-packet/releases/latest/`, but we haven't actually released the config file there yet. That will continue to be the case until we cut a release.

