### PR TITLE
load manifest file as part of github release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - arm64
 release:
   extra_files:
-    - glob: "./out/release/infrastructure-packet/{{ .Tag }}/*"
+    - glob: "./out/release/infrastructure-packet/v*/*"
 dockers:
   - image_templates:
       - "packethost/cluster-api-provider-packet:latest-arm64"


### PR DESCRIPTION
It looks like gorelaser does not support templating `{{ .Tag }}` as
release blob file.