### PR TITLE
buildx has some requirements like having a platform

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,4 +47,7 @@ publishers:
     - capp-linux
     name: "buildx"
     dir: "{{ dir .ArtifactPath }}/capp-linux_linux_{{ .Arch }}"
-    cmd: 'docker buildx build --push --platform linux/{{ .Arch }} -t packethost/cluster-api-provider-packet:latest-{{ .Arch }} -t packethost/cluster-api-provider-packet:{{ .Tag }}-{{ .Arch }} -f ../../Dockerfile.goreleaser .'
+    cmd: '../../scripts/multi_arch_docker_release.sh'
+    env:
+      - TAG={{ .Tag }}
+      - ARCH={{ .Arch }}

--- a/scripts/multi_arch_docker_release.sh
+++ b/scripts/multi_arch_docker_release.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+docker buildx create --use --name build --node build --driver-opt network=host
+docker buildx build --push --platform linux/${ARCH} \
+    -t packethost/cluster-api-provider-packet:latest-${ARCH} \
+    -t packethost/cluster-api-provider-packet:${TAG}-${ARCH} \
+    -f ../../Dockerfile.goreleaser .
+


### PR DESCRIPTION
This failed during our last build

```
auto-push is currently not implemented for docker driver
```

Gooling it looks like by default docker does not work for auto push, but
if you create a non-default one it works