### PR TITLE
buildx unauthorized

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,11 @@ jobs:
         run: git fetch --prune --unshallow
       - name: Get the version
         run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - uses: azure/docker-login@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: docker login
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${{ secret.docker_username }}" --password-stdin docker.io
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -41,9 +42,3 @@ jobs:
           args: release --rm-dist --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update docker manifest
-        run: |
-          docker buildx imagetools create \
-            -t packethost/cluster-api-provider-packet:$VERSION \
-            packethost/cluster-api-provider-packet:$VERSION-amd64 \
-            packethost/cluster-api-provider-packet:$VERSION-arm64

--- a/scripts/multi_arch_docker_release.sh
+++ b/scripts/multi_arch_docker_release.sh
@@ -1,9 +1,21 @@
 #!/bin/sh
 set -e
 
+# This has to be set otherwise the default driver will not work
 docker buildx create --use --name build --node build --driver-opt network=host
+
 docker buildx build --push --platform linux/${ARCH} \
     -t packethost/cluster-api-provider-packet:latest-${ARCH} \
     -t packethost/cluster-api-provider-packet:${TAG}-${ARCH} \
     -f ../../Dockerfile.goreleaser .
 
+# Update the manifest for the new release
+docker buildx imagetools create \
+  -t packethost/cluster-api-provider-packet:${TAG} \
+  packethost/cluster-api-provider-packet:${TAG}-${ARCH} \
+  packethost/cluster-api-provider-packet:${TAG}-${ARCH}
+
+docker buildx imagetools create \
+  -t packethost/cluster-api-provider-packet:latest \
+  packethost/cluster-api-provider-packet:latest-${ARCH} \
+  packethost/cluster-api-provider-packet:latest-${ARCH}


### PR DESCRIPTION
During the last release gh action I got this error:

```
server message: insufficient_scope: authorization failed
```

Looking around I found this:

https://github.com/docker/buildx/issues/202#issuecomment-597375245

Also, -1 action to use