### PR TITLE
packethost/cluster-api-packet-controller is the default image name

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,6 +8,6 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: packethost/cluster-api-packet-controller
+      - image: packethost/cluster-api-provider-packet
         name: manager
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Something changed along the way and the default image name used to
generate the infrastructure template is not right