### PR TITLE
fix: error retrieving bootstrap secret from kube api

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -61,6 +61,7 @@ type PacketMachineReconciler struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=packetmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=packetmachines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 
 func (r *PacketMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx := context.Background()


### PR DESCRIPTION
The manager has to be able to retrieve secrets because that's how it
lookup bootstrap information. We didn't set the right permission

```
$ kubectl logs -f cluster-api-provider-packet-controller-manager-89c9f95b8-49hlq -n cluster-api-provider-packet-system -c manager -f
E0526 15:16:07.696352       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:cluster-api-provider-packet-system:default" cannot list resource "secrets" in API group "" at the cluster scope
E0526 15:16:08.698025       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:cluster-api-provider-packet-system:default" cannot list resource "secrets" in API group "" at the cluster scope
E0526 15:16:09.699755       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:cluster-api-provider-packet-system:default" cannot list resource "secrets" in API group "" at the cluster scope
E0526 15:16:10.700982       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:cluster-api-provider-packet-system:default" cannot list resource "secrets" in API group "" at the cluster scope
E0526 15:16:11.702393       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:cluster-api-provider-packet-system:default" cannot list resource "secrets" in API group "" at the cluster scope
E0526 15:16:12.704717       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:cluster-api-provider-packet-system:default" cannot list resource "secrets" in API group "" at the cluster scope
```