### PR TITLE
remove calico from cluster template

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -19,7 +19,6 @@ spec:
     - systemctl enable docker
     - systemctl start docker
   postKubeadmCommands:
-    - "kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://docs.projectcalico.org/v3.11/manifests/calico.yaml"
     - "kubectl --kubeconfig /etc/kubernetes/admin.conf create secret generic -n kube-system packet-cloud-config --from-literal=cloud-sa.json='{\"apiKey\": \"{{ .apiKey }}\",\"projectID\": \"${PROJECT_ID}\"}'"
     - "kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://raw.githubusercontent.com/packethost/packet-ccm/master/deploy/releases/v1.0.0/deployment.yaml"
   initConfiguration:


### PR DESCRIPTION
I forgot this line during previous tests.
The CNI installation is a follow-up step that users have to take by
their own.

Or they can write their own cluster.yaml that contains what they like.

Fixed #11 